### PR TITLE
RBF bugfix and a method to regularization of the penultimate layer

### DIFF
--- a/config/method/composer_penultimate_layer_reg_rbf.yaml
+++ b/config/method/composer_penultimate_layer_reg_rbf.yaml
@@ -1,0 +1,8 @@
+_partial_: True
+_target_: method.Composer
+criterion: MahalanobisDistanceLoss
+first_lr: 0.01
+lr: 0.01
+plugins:
+  - _target_: method.PenultimateLayerReg
+    alpha: 0.4

--- a/config/method/composer_two_penultimate_layer_reg_rbf.yaml
+++ b/config/method/composer_two_penultimate_layer_reg_rbf.yaml
@@ -1,0 +1,10 @@
+_partial_: True
+_target_: method.Composer
+criterion: MahalanobisDistanceLoss
+first_lr: 0.01
+lr: 0.01
+plugins:
+  - _target_: method.RBFNeuronOutReg
+    alpha: 0.9999999999999999999999
+  - _target_: method.PenultimateLayerReg
+    alpha: 0.01

--- a/config/penultimate_layer_reg_rbf.yaml
+++ b/config/penultimate_layer_reg_rbf.yaml
@@ -1,0 +1,28 @@
+defaults:
+  - _self_
+  - dataset: mnist
+  - scenario: class_inc
+  - model: mlp_rbf
+  - method: composer_rbf_penultimate_layer_reg
+
+exp:
+  run_func:
+    _target_: experiment.experiment
+  seed: 42
+  log_dir: # set during runtime to automatically created dir
+  batch_size: 32
+  epochs: 5
+  gen_cm: False
+  log_per_batch: False
+  detect_anomaly: False
+  cleanup: True
+
+fabric:
+  _target_: lightning.Fabric
+  num_nodes: 1
+  devices: 1
+  accelerator: cpu # or gpu
+
+wandb:
+  entity: ${oc.env:WANDB_ENTITY}
+  project: ${oc.env:WANDB_PROJECT}

--- a/src/method/__init__.py
+++ b/src/method/__init__.py
@@ -5,3 +5,4 @@ from .mas import MAS
 from .si import SI
 from .sharpening import Sharpening
 from .reg_rbf_neuron_outputs import RBFNeuronOutReg
+from .penultimate_layer_reg import PenultimateLayerReg

--- a/src/method/penultimate_layer_reg.py
+++ b/src/method/penultimate_layer_reg.py
@@ -1,0 +1,115 @@
+import logging
+import torch
+from src.method.method_plugin_abc import MethodPluginABC
+
+from copy import deepcopy
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+class PenultimateLayerReg(MethodPluginABC):
+    """
+    This class applies regularization to the penultimate layer to mitigate feature drift.
+    It is relevant only when RBFHead is used.
+    
+    Attributes:
+        params_buffer (dict): Stores model parameters for regularization.
+        alpha (float): Regularization strength.
+    """
+
+    def __init__(self, alpha: float):
+        """
+        Initializes the feature drift regularization method for the penultimate layer.
+
+        Args:
+            alpha (float): Regularization coefficient.
+        """
+        super().__init__()
+        self.params_buffer = {}
+
+        self.alpha = alpha
+        log.info(f"PenultimateLayerReg initialized with alpha={alpha}")
+
+    def setup_task(self, task_id: int):
+        """
+        Sets up a new task and stores parameters from the penultimate layer
+        and incremental classification head (RBF).
+
+        Args:
+            task_id (int): Unique task identifier.
+        """
+        
+        def extract_layer_params(layer, idx, classes=None):
+            if type(layer).__name__ in ["RBFLayer", "RBFHeadLayer"]:
+                weights = layer.weights.detach().clone() if classes is None else None
+                kernels_centers = layer.kernels_centers[:classes, :].detach().clone() if classes is not None else layer.kernels_centers.detach().clone()
+                log_shapes = layer.log_shapes[:classes, :].detach().clone() if classes is not None else layer.log_shapes.detach().clone()
+                return {
+                    f"weights_{idx}": weights,
+                    f"kernels_centers_{idx}": kernels_centers,
+                    f"log_shapes_{idx}": log_shapes
+                }
+            elif isinstance(layer, torch.nn.Linear):
+                weights = layer.weight.detach().clone()
+                biases = layer.bias.detach().clone() if layer.bias is not None else None
+                return {
+                    f"linear_weights_{idx}": weights,
+                    f"linear_biases_{idx}": biases
+                }
+            return {}
+
+        self.task_id = task_id
+
+        if task_id > 0:
+            model = self.module.module
+            for module in model.children():
+                if isinstance(module, torch.nn.ModuleList):
+                    for idx, layer in enumerate(module):
+                        self.params_buffer.update(extract_layer_params(layer, idx))
+                elif type(module).__name__ == "IncrementalClassifier":
+                    layer = module.classifier
+                    old_nclasses = module.old_nclasses
+                    if type(layer).__name__ == "RBFHeadLayer":
+                        self.params_buffer.update(extract_layer_params(layer, "head", old_nclasses))
+
+            with torch.no_grad():   
+                self.old_module = deepcopy(self.module)
+                for p in self.old_module.parameters():
+                    p.requires_grad = False
+                self.old_module.eval()
+
+    def forward(self, x, y, loss, preds):
+        """
+        Forward pass.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            y (torch.Tensor): Target tensor.
+            loss (torch.Tensor): Initial loss.
+            preds (torch.Tensor): Model predictions.
+        
+        Returns:
+            tuple: Updated loss and predictions.
+        """
+        if self.task_id > 0:
+            penultimate_activations_current = self.module.activations[-1]
+            _ = self.old_module(x)
+            penultimate_activations_old = self.old_module.activations[-1].clone().detach()
+
+            kernels_centers = self.params_buffer["kernels_centers_head"]
+            sigma = self.params_buffer["log_shapes_head"].exp()
+
+            batch_size = x.size(0)
+            out_features, in_features = kernels_centers.shape
+           
+            c = kernels_centers.expand(batch_size, out_features, in_features)
+            sigma = sigma.expand(batch_size, out_features, in_features)
+            penultimate_activations_old = penultimate_activations_old.view(batch_size, 1, in_features)
+            penultimate_activations_current = penultimate_activations_current.view(batch_size, 1, in_features)
+
+            weight_factor = torch.exp(-((penultimate_activations_old - c) / sigma) ** 2)
+            weighted_diff = weight_factor * (penultimate_activations_old - penultimate_activations_current)
+            reg_loss = self.alpha * torch.norm(weighted_diff, p=2)
+            loss += reg_loss
+        
+        return loss, preds

--- a/src/method/reg_rbf_neuron_outputs.py
+++ b/src/method/reg_rbf_neuron_outputs.py
@@ -131,7 +131,9 @@ class RBFNeuronOutReg(MethodPluginABC):
                             # Retrieve old stored parameters
                             _, C_old, Sigma_old = get_old_rbf_layer_params("head")
 
-                            # Add regularization loss
+                            assert self.alpha >= 0.0 and self.alpha <= 1.0, f"Alpha parameter should be within [0,1] interval"
+
+                            loss *= (1-self.alpha)
                             loss += self.alpha * self.compute_head_integral_gaussian(
                                 C_old=C_old, C_curr=C_curr,
                                 Sigma_old=Sigma_old, Sigma_curr=Sigma_curr
@@ -224,6 +226,7 @@ class RBFNeuronOutReg(MethodPluginABC):
         # torch.exp(F_integrals_max) is a constant and has to be included to
         # prevent overflow. It does not change the final minimum.
         final_integral = torch.exp(integrals_max - F_integrals_max) * final_integral
+
         final_integral = final_integral.mean()
 
         return final_integral

--- a/src/model/layer/rbf.py
+++ b/src/model/layer/rbf.py
@@ -295,7 +295,7 @@ class RBFLayer(LocalModule):
         sigma = self.log_shapes.exp().expand(batch_size, self.num_kernels,
                                              self.in_features)
 
-        diff = sigma * (input.view(batch_size, 1, self.in_features) - c)
+        diff = (input.view(batch_size, 1, self.in_features) - c) / sigma
         diff *= self.mask
 
         # Apply norm function; c has size B x num_kernels

--- a/src/model/layer/rbf_head.py
+++ b/src/model/layer/rbf_head.py
@@ -118,7 +118,7 @@ class RBFHeadLayer(LocalModule):
         sigma = self.log_shapes.exp().expand(batch_size, self.out_features,
                                              self.in_features)
 
-        diff = sigma * (input.view(batch_size, 1, self.in_features) - c)
+        diff = (input.view(batch_size, 1, self.in_features) - c) / sigma
 
         # Apply norm function; c has size B x out_features
         r = self.norm_function(diff)


### PR DESCRIPTION
- There was a bug in the RBF hidden layers and RBFHead, which relied on dividing by sigma instead of multiplying.
- I wrote a new method that restricts the values of the penultimate layer.