### PR TITLE
Small fixes

### DIFF
--- a/config/method/composer_ewc.yaml
+++ b/config/method/composer_ewc.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: CrossEntropyLoss
 first_lr: 0.001
 lr: 0.001
+criterion_scale: 1e-5
 plugins:
   - _target_: method.EWC
     alpha: 2000

--- a/config/method/composer_ewc.yaml
+++ b/config/method/composer_ewc.yaml
@@ -7,3 +7,4 @@ criterion_scale: 1e-5
 plugins:
   - _target_: method.EWC
     alpha: 2000
+    lamb: 0.5

--- a/config/method/composer_ewc.yaml
+++ b/config/method/composer_ewc.yaml
@@ -5,4 +5,4 @@ first_lr: 0.001
 lr: 0.001
 plugins:
   - _target_: method.EWC
-    alpha: 0.4
+    alpha: 2000

--- a/config/method/composer_lwf.yaml
+++ b/config/method/composer_lwf.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: CrossEntropyLoss
 first_lr: 0.001
 lr: 0.001
+criterion_scale: 1e-5
 plugins:
   - _target_: method.LwF
     T: 2

--- a/config/method/composer_mas.yaml
+++ b/config/method/composer_mas.yaml
@@ -7,3 +7,4 @@ criterion_scale: 1e-5
 plugins:
   - _target_: method.MAS
     alpha: 0.4
+    lamb: 0.5

--- a/config/method/composer_mas.yaml
+++ b/config/method/composer_mas.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: CrossEntropyLoss
 first_lr: 0.001
 lr: 0.001
+criterion_scale: 1e-5
 plugins:
   - _target_: method.MAS
     alpha: 0.4

--- a/config/method/composer_naive.yaml
+++ b/config/method/composer_naive.yaml
@@ -3,3 +3,4 @@ _target_: method.Composer
 criterion: CrossEntropyLoss
 first_lr: 0.01
 lr: 0.01
+criterion_scale: 1e-5

--- a/config/method/composer_penultimate_layer_reg_rbf.yaml
+++ b/config/method/composer_penultimate_layer_reg_rbf.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: MahalanobisDistanceLoss
 first_lr: 0.01
 lr: 0.01
+criterion_scale: 1e-5
 plugins:
   - _target_: method.PenultimateLayerReg
     alpha: 0.4

--- a/config/method/composer_rbf_neuron_output_reg.yaml
+++ b/config/method/composer_rbf_neuron_output_reg.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: MahalanobisDistanceLoss
 first_lr: 0.01
 lr: 0.01
+criterion_scale: 1e-5
 plugins:
   - _target_: method.RBFNeuronOutReg
     alpha: 0.4

--- a/config/method/composer_sharpening.yaml
+++ b/config/method/composer_sharpening.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: CrossEntropyLoss
 first_lr: 0.01
 lr: 0.01
+criterion_scale: 1e-5
 plugins:
   - _target_: method.Sharpening
     K: 64

--- a/config/method/composer_si.yaml
+++ b/config/method/composer_si.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: CrossEntropyLoss
 first_lr: 0.001
 lr: 0.001
+criterion_scale: 1e-5
 plugins:
   - _target_: method.SI
     alpha: 2048

--- a/config/method/composer_si.yaml
+++ b/config/method/composer_si.yaml
@@ -5,4 +5,4 @@ first_lr: 0.001
 lr: 0.001
 plugins:
   - _target_: method.SI
-    alpha: 0.4
+    alpha: 2048

--- a/config/method/composer_two_ewc.yaml
+++ b/config/method/composer_two_ewc.yaml
@@ -7,4 +7,4 @@ plugins:
   - _target_: method.RBFNeuronOutReg
     alpha: 0.4
   - _target_: method.EWC
-    alpha: 0.4
+    alpha: 2000

--- a/config/method/composer_two_ewc.yaml
+++ b/config/method/composer_two_ewc.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: MahalanobisDistanceLoss
 first_lr: 0.001
 lr: 0.001
+criterion_scale: 1e-5
 plugins:
   - _target_: method.RBFNeuronOutReg
     alpha: 0.4

--- a/config/method/composer_two_ewc.yaml
+++ b/config/method/composer_two_ewc.yaml
@@ -9,3 +9,4 @@ plugins:
     alpha: 0.4
   - _target_: method.EWC
     alpha: 2000
+    lamb: 0.5

--- a/config/method/composer_two_lwf.yaml
+++ b/config/method/composer_two_lwf.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: MahalanobisDistanceLoss
 first_lr: 0.001
 lr: 0.001
+criterion_scale: 1e-5
 plugins:
   - _target_: method.RBFNeuronOutReg
     alpha: 0.4

--- a/config/method/composer_two_mas.yaml
+++ b/config/method/composer_two_mas.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: MahalanobisDistanceLoss
 first_lr: 0.001
 lr: 0.001
+criterion_scale: 1e-5
 plugins:
   - _target_: method.RBFNeuronOutReg
     alpha: 0.4

--- a/config/method/composer_two_mas.yaml
+++ b/config/method/composer_two_mas.yaml
@@ -9,3 +9,4 @@ plugins:
     alpha: 0.4
   - _target_: method.MAS
     alpha: 0.4
+    lamb: 0.5

--- a/config/method/composer_two_penultimate_layer_reg_rbf.yaml
+++ b/config/method/composer_two_penultimate_layer_reg_rbf.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: MahalanobisDistanceLoss
 first_lr: 0.01
 lr: 0.01
+criterion_scale: 1e-5
 plugins:
   - _target_: method.RBFNeuronOutReg
     alpha: 0.9999999999999999999999

--- a/config/method/composer_two_sharpening.yaml
+++ b/config/method/composer_two_sharpening.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: MahalanobisDistanceLoss
 first_lr: 0.001
 lr: 0.001
+criterion_scale: 1e-5
 plugins:
   - _target_: method.RBFNeuronOutReg
     alpha: 0.4

--- a/config/method/composer_two_si.yaml
+++ b/config/method/composer_two_si.yaml
@@ -3,6 +3,7 @@ _target_: method.Composer
 criterion: MahalanobisDistanceLoss
 first_lr: 0.001
 lr: 0.001
+criterion_scale: 1e-5
 plugins:
   - _target_: method.RBFNeuronOutReg
     alpha: 0.4

--- a/config/method/composer_two_si.yaml
+++ b/config/method/composer_two_si.yaml
@@ -7,4 +7,4 @@ plugins:
   - _target_: method.RBFNeuronOutReg
     alpha: 0.4
   - _target_: method.SI
-    alpha: 0.4
+    alpha: 2048

--- a/scripts/normal/ewc/ewc_gs.yaml
+++ b/scripts/normal/ewc/ewc_gs.yaml
@@ -67,6 +67,10 @@ parameters:
     distribution: uniform      
     min: 1000
     max: 3000
+  method.plugins.0.lamb:
+    distribution: uniform
+    min: 0.1
+    max: 0.9
 
 
 command:

--- a/scripts/normal/ewc/ewc_gs.yaml
+++ b/scripts/normal/ewc/ewc_gs.yaml
@@ -49,6 +49,10 @@ parameters:
     value: method.Composer
   method.criterion: 
     value: CrossEntropyLoss
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.first_lr: 
     distribution: log_uniform_values
     min: 0.0001

--- a/scripts/normal/ewc/ewc_gs.yaml
+++ b/scripts/normal/ewc/ewc_gs.yaml
@@ -61,8 +61,8 @@ parameters:
     value: method.EWC
   method.plugins.0.alpha: 
     distribution: uniform      
-    min: 0.1
-    max: 1.0
+    min: 1000
+    max: 3000
 
 
 command:

--- a/scripts/normal/lwf/lwf_gs.yaml
+++ b/scripts/normal/lwf/lwf_gs.yaml
@@ -53,6 +53,10 @@ parameters:
     distribution: log_uniform_values
     min: 0.0001
     max: 0.01
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.lr: 
     distribution: log_uniform_values 
     min: 0.0001

--- a/scripts/normal/mas/mas_gs.yaml
+++ b/scripts/normal/mas/mas_gs.yaml
@@ -67,6 +67,10 @@ parameters:
     distribution: uniform      
     min: 0.1
     max: 1.0
+  method.plugins.0.lamb:
+    distribution: uniform
+    min: 0.1
+    max: 0.9
 
 
 command:

--- a/scripts/normal/mas/mas_gs.yaml
+++ b/scripts/normal/mas/mas_gs.yaml
@@ -53,6 +53,10 @@ parameters:
     distribution: log_uniform_values
     min: 0.0001
     max: 0.01
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.lr: 
     distribution: log_uniform_values 
     min: 0.0001

--- a/scripts/normal/naive/naive_gs.yaml
+++ b/scripts/normal/naive/naive_gs.yaml
@@ -37,6 +37,10 @@ parameters:
     value: 2          
   model.sizes:
     value: [1024, 400]
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   model.head_type: 
     value: Normal
   model.layers: 

--- a/scripts/normal/sharpening/sharpening_gs.yaml
+++ b/scripts/normal/sharpening/sharpening_gs.yaml
@@ -49,6 +49,10 @@ parameters:
     value: method.Composer
   method.criterion: 
     value: CrossEntropyLoss
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.first_lr: 
     distribution: log_uniform_values
     min: 0.0001

--- a/scripts/normal/si/si_gs.yaml
+++ b/scripts/normal/si/si_gs.yaml
@@ -53,6 +53,10 @@ parameters:
     distribution: log_uniform_values
     min: 0.0001
     max: 0.01
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.lr: 
     distribution: log_uniform_values 
     min: 0.0001

--- a/scripts/normal/si/si_gs.yaml
+++ b/scripts/normal/si/si_gs.yaml
@@ -61,8 +61,8 @@ parameters:
     value: method.SI
   method.plugins.0.alpha: 
     distribution: uniform      
-    min: 0.1
-    max: 1.0
+    min: 1000
+    max: 3000
 
 
 command:

--- a/scripts/rbf/ewc/ewc_gs.yaml
+++ b/scripts/rbf/ewc/ewc_gs.yaml
@@ -79,8 +79,8 @@ parameters:
     value: method.EWC
   method.plugins.0.alpha: 
     distribution: uniform      
-    min: 0.1
-    max: 1.0
+    min: 1000
+    max: 3000
 
 
 command:

--- a/scripts/rbf/ewc/ewc_gs.yaml
+++ b/scripts/rbf/ewc/ewc_gs.yaml
@@ -85,6 +85,10 @@ parameters:
     distribution: uniform      
     min: 1000
     max: 3000
+  method.plugins.0.lamb:
+    distribution: uniform
+    min: 0.1
+    max: 0.9
 
 
 command:

--- a/scripts/rbf/ewc/ewc_gs.yaml
+++ b/scripts/rbf/ewc/ewc_gs.yaml
@@ -67,6 +67,10 @@ parameters:
     value: method.Composer
   method.criterion: 
     values: [MahalanobisDistanceLoss, CrossEntropyLoss]
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.first_lr: 
     distribution: log_uniform_values
     min: 0.0001

--- a/scripts/rbf/lwf/lwf_gs.yaml
+++ b/scripts/rbf/lwf/lwf_gs.yaml
@@ -67,6 +67,10 @@ parameters:
     value: method.Composer
   method.criterion: 
     values: [MahalanobisDistanceLoss, CrossEntropyLoss]
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.first_lr: 
     distribution: log_uniform_values
     min: 0.0001

--- a/scripts/rbf/mas/mas_gs.yaml
+++ b/scripts/rbf/mas/mas_gs.yaml
@@ -71,6 +71,10 @@ parameters:
     distribution: log_uniform_values
     min: 0.0001
     max: 0.01
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.lr: 
     distribution: log_uniform_values 
     min: 0.0001

--- a/scripts/rbf/mas/mas_gs.yaml
+++ b/scripts/rbf/mas/mas_gs.yaml
@@ -85,6 +85,10 @@ parameters:
     distribution: uniform      
     min: 0.1
     max: 1.0
+  method.plugins.0.lamb:
+    distribution: uniform
+    min: 0.1
+    max: 0.9
 
 
 command:

--- a/scripts/rbf/naive/naive_gs.yaml
+++ b/scripts/rbf/naive/naive_gs.yaml
@@ -67,6 +67,10 @@ parameters:
     value: method.Composer
   method.criterion: 
     values: [MahalanobisDistanceLoss, CrossEntropyLoss]
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.first_lr: 
     distribution: log_uniform_values
     min: 0.0001

--- a/scripts/rbf/neuron_reg/neuron_reg_gs.yaml
+++ b/scripts/rbf/neuron_reg/neuron_reg_gs.yaml
@@ -71,6 +71,10 @@ parameters:
     distribution: log_uniform_values
     min: 0.0001
     max: 0.01
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.lr: 
     distribution: log_uniform_values 
     min: 0.0001

--- a/scripts/rbf/sharpening/sharpening_gs.yaml
+++ b/scripts/rbf/sharpening/sharpening_gs.yaml
@@ -75,6 +75,10 @@ parameters:
     distribution: log_uniform_values 
     min: 0.0001
     max: 0.01
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.plugins.0._target_:
     value: method.Sharpening
   method.plugins.0.alpha: 

--- a/scripts/rbf/si/si_gs.yaml
+++ b/scripts/rbf/si/si_gs.yaml
@@ -75,6 +75,10 @@ parameters:
     distribution: log_uniform_values 
     min: 0.0001
     max: 0.01
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.plugins.0._target_:
     value: method.SI
   method.plugins.0.alpha: 

--- a/scripts/rbf/si/si_gs.yaml
+++ b/scripts/rbf/si/si_gs.yaml
@@ -83,8 +83,8 @@ parameters:
     value: method.SI
   method.plugins.0.alpha: 
     distribution: uniform      
-    min: 0.1
-    max: 1.0
+    min: 1000
+    max: 3000
 
 command:
   - ${env}

--- a/scripts/two/ewc/ewc_gs.yaml
+++ b/scripts/two/ewc/ewc_gs.yaml
@@ -67,6 +67,10 @@ parameters:
     value: method.Composer
   method.criterion: 
     value: MahalanobisDistanceLoss
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.first_lr: 
     distribution: log_uniform_values
     min: 0.0001

--- a/scripts/two/ewc/ewc_gs.yaml
+++ b/scripts/two/ewc/ewc_gs.yaml
@@ -85,8 +85,8 @@ parameters:
     value: method.EWC
   method.plugins.1.alpha: 
     distribution: uniform      
-    min: 0.1
-    max: 1.0
+    min: 1000
+    max: 3000
 
 
 command:

--- a/scripts/two/ewc/ewc_gs.yaml
+++ b/scripts/two/ewc/ewc_gs.yaml
@@ -91,6 +91,10 @@ parameters:
     distribution: uniform      
     min: 1000
     max: 3000
+  method.plugins.1.lamb:
+    distribution: uniform
+    min: 0.1
+    max: 0.9
 
 
 command:

--- a/scripts/two/lwf/lwf_gs.yaml
+++ b/scripts/two/lwf/lwf_gs.yaml
@@ -67,6 +67,10 @@ parameters:
     value: method.Composer
   method.criterion: 
     value: MahalanobisDistanceLoss
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.first_lr: 
     distribution: log_uniform_values
     min: 0.0001

--- a/scripts/two/mas/mas_gs.yaml
+++ b/scripts/two/mas/mas_gs.yaml
@@ -91,6 +91,10 @@ parameters:
     distribution: uniform      
     min: 0.4
     max: 1.0
+  method.plugins.1.lamb:
+    distribution: uniform
+    min: 0.1
+    max: 0.9
 
 
 command:

--- a/scripts/two/mas/mas_gs.yaml
+++ b/scripts/two/mas/mas_gs.yaml
@@ -71,6 +71,10 @@ parameters:
     distribution: log_uniform_values
     min: 0.0001
     max: 0.01
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.lr: 
     distribution: log_uniform_values 
     min: 0.0001

--- a/scripts/two/sharpening/sharpening_gs.yaml
+++ b/scripts/two/sharpening/sharpening_gs.yaml
@@ -71,6 +71,10 @@ parameters:
     distribution: log_uniform_values
     min: 0.0001
     max: 0.01
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.lr: 
     distribution: log_uniform_values 
     min: 0.0001

--- a/scripts/two/si/si_gs.yaml
+++ b/scripts/two/si/si_gs.yaml
@@ -67,6 +67,10 @@ parameters:
     value: method.Composer
   method.criterion: 
     value: MahalanobisDistanceLoss
+  method.criterion_scale:
+    distribution: uniform
+    min: 1e-8
+    max: 1.0
   method.first_lr: 
     distribution: log_uniform_values
     min: 0.0001

--- a/scripts/two/si/si_gs.yaml
+++ b/scripts/two/si/si_gs.yaml
@@ -85,8 +85,8 @@ parameters:
     value: method.SI
   method.plugins.1.alpha: 
     distribution: uniform      
-    min: 0.4
-    max: 1.0
+    min: 1000
+    max: 3000
 
 command:
   - ${env}

--- a/src/method/composer.py
+++ b/src/method/composer.py
@@ -121,7 +121,7 @@ class Composer:
         """
 
         if self.gamma is not None and self.reg_type is not None:
-            loss = (1-self.gamma)*loss+self.gamma*regularization(self.module.activations, self.reg_type)
+            loss += self.gamma*regularization(self.module.activations, self.reg_type)
         return loss
 
 

--- a/src/method/composer.py
+++ b/src/method/composer.py
@@ -24,6 +24,7 @@ class Composer:
         optimizer (Optional[optim.Optimizer]): The optimizer for training.
         first_lr (float): The learning rate for the first task.
         lr (float): The learning rate for subsequent tasks.
+        criterion_scale (float): The regularization strength of the used criterion loss function.
         reg_type (Optional[str]): The type of regularization to apply.
         gamma (Optional[float]): The regularization strength.
         clipgrad (Optional[float]): The gradient clipping value.
@@ -49,6 +50,7 @@ class Composer:
         criterion: str, 
         first_lr: float, 
         lr: float,
+        criterion_scale: float,
         reg_type: Optional[str]=None,
         gamma: Optional[float]=None,
         clipgrad: Optional[float]=None,
@@ -77,6 +79,7 @@ class Composer:
         self.optimizer = None
         self.first_lr = first_lr
         self.lr = lr
+        self.criterion_scale = criterion_scale
         self.reg_type = reg_type
         self.gamma = gamma
         self.clipgrad = clipgrad
@@ -154,6 +157,7 @@ class Composer:
 
         preds = self.module(x)
         loss = self.criterion(preds, y)
+        loss *= self.criterion_scale
         loss = self._add_reg(loss)
 
         old_loss = loss

--- a/src/method/ewc.py
+++ b/src/method/ewc.py
@@ -90,8 +90,7 @@ class EWC(MethodPluginABC):
         self.data_buffer.add((x, y))
 
         if self.task_id > 0:
-            loss *= self.alpha
-            loss += (1-self.alpha)*param_change_loss(self.module, self.fisher_diag, self.params_buffer)
+            loss += self.alpha*param_change_loss(self.module, self.fisher_diag, self.params_buffer)
         return loss, preds
 
 

--- a/src/method/lwf.py
+++ b/src/method/lwf.py
@@ -89,6 +89,5 @@ class LwF(MethodPluginABC):
             with torch.no_grad():
                 old_preds = self.old_module(x)
 
-            loss *= self.alpha
-            loss += distillation_loss(preds, old_preds, self.T)*(1-self.alpha)
+            loss += self.alpha*distillation_loss(preds, old_preds, self.T)
         return loss, preds

--- a/src/method/mas.py
+++ b/src/method/mas.py
@@ -105,8 +105,7 @@ class MAS(MethodPluginABC):
         self.data_buffer.add((x, y))
 
         if self.task_id > 0:
-            loss *= self.alpha
-            loss += (1-self.alpha)*param_change_loss(self.module, self.importance, self.params_buffer)
+            loss += self.alpha*param_change_loss(self.module, self.importance, self.params_buffer)
         return loss, preds
     
 

--- a/src/method/reg_rbf_neuron_outputs.py
+++ b/src/method/reg_rbf_neuron_outputs.py
@@ -131,9 +131,6 @@ class RBFNeuronOutReg(MethodPluginABC):
                             # Retrieve old stored parameters
                             _, C_old, Sigma_old = get_old_rbf_layer_params("head")
 
-                            assert self.alpha >= 0.0 and self.alpha <= 1.0, f"Alpha parameter should be within [0,1] interval"
-
-                            loss *= (1-self.alpha)
                             loss += self.alpha * self.compute_head_integral_gaussian(
                                 C_old=C_old, C_curr=C_curr,
                                 Sigma_old=Sigma_old, Sigma_curr=Sigma_curr

--- a/src/method/si.py
+++ b/src/method/si.py
@@ -106,8 +106,7 @@ class SI(MethodPluginABC):
                 self.omega[name] += p.grad * (-delta_param) / (delta_param ** 2 + self.eps)
                 self.prev_param[name] = p.data.clone().detach()
 
-        loss *= self.alpha
-        loss += (1-self.alpha)*param_change_loss(self.module, self.importance, params_buffer)
+        loss += self.alpha*param_change_loss(self.module, self.importance, params_buffer)
         return loss, preds
     
 


### PR DESCRIPTION
I propose the following changes:
   - A new hyperparameter has been added to scale the criterion loss.
   - The scaling of alpha * loss_criterion + (1 - alpha) * loss_reg has been removed, as it is already included.
   - I added an option to weight importance in MAS and EWC, which is a standard trick in CL to maximize results.
   - I adjusted the grids to reflect the new changes.