### PR TITLE
MISC

### DIFF
--- a/config/method/composer_naive.yaml
+++ b/config/method/composer_naive.yaml
@@ -4,3 +4,4 @@ criterion: CrossEntropyLoss
 first_lr: 0.01
 lr: 0.01
 criterion_scale: 1e-5
+reset_rbf_mask: True

--- a/config/model/mlp_rbf.yaml
+++ b/config/model/mlp_rbf.yaml
@@ -3,16 +3,17 @@ initial_out_features: 2
 sizes: [1024, 100, 8]
 layers: ["RBF", "RBF"]
 head_type: SingleRBFHead # MultiRBFHead
-num_kernels: 100
-no_groups: 50
-growing_mask: True
-no_mask_update_iterations: 1500
-local_linear: False
-normalization: True
-start_empty: True
-radial_function: 
-  _target_: model.layer.rbf.rbf_gaussian
-  _partial_: true
-norm_function: 
-  _target_: model.layer.rbf.l_norm
-  _partial_: true
+config:
+  num_kernels: 100
+  no_groups: 50
+  growing_mask: True
+  no_mask_update_iterations: 1500
+  local_linear: False
+  normalization: True
+  start_empty: True
+  radial_function: 
+    _target_: model.layer.rbf.rbf_gaussian
+    _partial_: true
+  norm_function: 
+    _target_: model.layer.rbf.l_norm
+    _partial_: true

--- a/config/model/mlp_rbf.yaml
+++ b/config/model/mlp_rbf.yaml
@@ -9,6 +9,7 @@ growing_mask: True
 no_mask_update_iterations: 1500
 local_linear: False
 normalization: True
+start_empty: True
 radial_function: 
   _target_: model.layer.rbf.rbf_gaussian
   _partial_: true

--- a/config/naive_split_mnist_mlp_rbf.yaml
+++ b/config/naive_split_mnist_mlp_rbf.yaml
@@ -11,7 +11,7 @@ exp:
   seed: 42
   log_dir: # set during runtime to automatically created dir
   batch_size: 32
-  epochs: 5
+  epochs: 1
   gen_cm: False
   log_per_batch: False
   detect_anomaly: False

--- a/src/method/composer.py
+++ b/src/method/composer.py
@@ -159,7 +159,7 @@ class Composer:
 
         if self.reset_rbf_mask and task_id > 0:
             for layer in self.module.layers+[self.module.head]:
-                if isinstance(layer, RBFLayer):
+                if isinstance(layer, RBFLayer) and layer.growing_mask:
                     layer.mask = layer.init_group_mask()
 
         self._setup_optim(task_id)

--- a/src/model/layer/rbf.py
+++ b/src/model/layer/rbf.py
@@ -144,7 +144,6 @@ class RBFLayer(LocalModule):
 
         self.no_mask_update_iterations = no_mask_update_iterations
         self.growing_mask = growing_mask
-        self.iteration = 0
 
         self._make_parameters()
 
@@ -197,7 +196,8 @@ class RBFLayer(LocalModule):
 
     def init_group_mask(self):
         """Initialize masks to define group of neurons within a neural network"""
-        mask = torch.zeros(self.num_kernels, self.in_features)
+
+        self.iteration = 0
         assert self.no_groups > 0, "Number of created groups should be greater than 0."
         group_size_neurons = self.num_kernels // self.no_groups
         group_size_features = self.in_features // self.no_groups


### PR DESCRIPTION
- Composer can now reset mask in each RBF layer per task if `reset_rbf_mask` option is used. NOTE: please use together with `start_empty: True` in rbf layer.
- MLP allows for config per layer. We can pass either one config for all layers or list of configs which will get applied in reverse order (i.e. head is first in config list). If config list is shorter than amount of layers `config[-1]` will be used in place of missing configs.
Example config with per layer list:
```
_target_: model.MLP
initial_out_features: 2
sizes: [1024, 100, 8]
layers: ["RBF", "RBF"]
head_type: MultiRBFHead
config:
  - num_kernels: 1
    no_groups: 1
    growing_mask: False
    no_mask_update_iterations: 1500
    local_linear: False
    normalization: True
    radial_function: 
      _target_: model.layer.rbf.rbf_gaussian
      _partial_: true
    norm_function: 
      _target_: model.layer.rbf.l_norm
      _partial_: true
  - num_kernels: 100
    no_groups: 50
    growing_mask: True
    no_mask_update_iterations: 1500
    local_linear: False
    normalization: True
    start_empty: True
    radial_function: 
      _target_: model.layer.rbf.rbf_gaussian
      _partial_: true
    norm_function: 
      _target_: model.layer.rbf.l_norm
      _partial_: true
```